### PR TITLE
Homoiconicity

### DIFF
--- a/src/components/code-editor/highlight.js
+++ b/src/components/code-editor/highlight.js
@@ -1,9 +1,8 @@
 /**
  * @file Syntax highlighting for the code editor.
  */
-import * as stringTools from './string-tools.js';
-import { Type } from '../../lang/types.mjs';
-
+import * as stringTools from "./string-tools.js";
+import { TokenType } from "../../lang/token.mjs";
 
 /**
  * Create a span
@@ -12,9 +11,11 @@ import { Type } from '../../lang/types.mjs';
  * @return {HTMLElement}
  */
 function span(innerText, classList) {
-  return Object.assign(document.createElement('span'), { innerText, classList });
+  return Object.assign(document.createElement("span"), {
+    innerText,
+    classList,
+  });
 }
-
 
 /**
  * Get an n-long string full of spaces.
@@ -22,12 +23,11 @@ function span(innerText, classList) {
  * @return {string}
  */
 function space(n) {
-  return stringTools.fillString(n, ' ');
+  return stringTools.fillString(n, " ");
 }
 
-
 /**
- * Generate some highlight-wrapped HTML from some source code, a list of 
+ * Generate some highlight-wrapped HTML from some source code, a list of
  * generated tokens, and a set of keywords.
  * @param {string} sourceString
  * @param {Token[]} tokens
@@ -37,7 +37,7 @@ function space(n) {
 export function highlight(sourceString, tokens, keywords) {
   const outputLines = [];
   let lineNumber = 0;
-  let currentLine = span('', 'line');
+  let currentLine = span("", "line");
 
   // Add front padding to the first line.
   currentLine.append(space(tokens[0].range[0]));
@@ -45,29 +45,29 @@ export function highlight(sourceString, tokens, keywords) {
   for (let i = 0; i < tokens.length; i++) {
     const token = tokens[i];
 
-    if (token.type === Type.EOF) continue;
+    if (token.type === TokenType.EOF) continue;
 
     // Make a new line.
     if (token.line !== lineNumber) {
       outputLines.push(currentLine);
 
       while (lineNumber < token.line - 1) {
-        outputLines.push(span('', 'line'));
+        outputLines.push(span("", "line"));
         lineNumber += 1;
       }
       lineNumber += 1;
 
-      currentLine = span('', 'line');
+      currentLine = span("", "line");
 
       // Search backwards for a line break.
-      const prevLineBreak = sourceString.lastIndexOf('\n', token.range[0]);
+      const prevLineBreak = sourceString.lastIndexOf("\n", token.range[0]);
 
       // Fill new line with leading space.
       currentLine.append(space(token.range[0] - prevLineBreak - 1));
     }
 
     // Make a syntax highlighted span for the token.
-    const className = Type.getString(token.type).toLowerCase();
+    const className = TokenType.getString(token.type).toLowerCase();
     const tokenSpan = span(sourceString.substring(...token.range), className);
 
     if (token.depth !== undefined) {
@@ -75,16 +75,16 @@ export function highlight(sourceString, tokens, keywords) {
     }
 
     if (keywords.has(token.str)) {
-      tokenSpan.classList.add('keyword');
+      tokenSpan.classList.add("keyword");
     }
 
     if (token.subpath && token.subpath.length) {
-      tokenSpan.classList.add('dynamic');
+      tokenSpan.classList.add("dynamic");
     }
 
     currentLine.append(tokenSpan);
 
-    if (tokens[i + 1].type === 'eof') continue;
+    if (tokens[i + 1].type === "eof") continue;
 
     const spaceToNext = tokens[i + 1].range[0] - token.range[1];
     currentLine.append(space(spaceToNext));
@@ -93,7 +93,7 @@ export function highlight(sourceString, tokens, keywords) {
   outputLines.push(currentLine);
 
   while (outputLines.length < stringTools.countLinebreaks(sourceString)) {
-    outputLines.push(span('', 'line'));
+    outputLines.push(span("", "line"));
   }
   return outputLines;
 }

--- a/src/lang/context.mjs
+++ b/src/lang/context.mjs
@@ -3,7 +3,7 @@
  */
 
 function error(message) {
-  throw new Error(`context – ${message}`);
+  throw new Error(`context - ${message}`);
 }
 
 export class Context {
@@ -15,24 +15,23 @@ export class Context {
     this.env = Object.setPrototypeOf({}, scope);
     this._constants = new Set();
     for (let i = 0; i < params.length; i++) {
-      if (params[i].val === '&' && params.length === i + 2) {
-        this.env[params[i + 1].val] = args.slice(i);
+      if (params[i] === "&" && params.length === i + 2) {
+        this.env[params[i + 1]] = args.slice(i);
         return;
       }
-      this.env[params[i].val] = args[i];
+      this.env[params[i]] = args[i];
     }
   }
-
 
   /**
    * Get the value of id in the context.
    * @param {string} id The identifier to get.
    * @param {string[]} subpath Nested subpath.
    * @return {any}
-   */ 
+   */
   get(id, subpath = undefined) {
     if (!(id in this.env)) {
-      error('no value found for key: ' + id);
+      error("no value found for key: " + id);
       return;
     }
 
@@ -43,11 +42,11 @@ export class Context {
     let [nestedVal, parent] = nested(this.env[id], subpath);
 
     if (nestedVal === undefined) {
-      error('subpath error for id: ' + id + ' and path: ' + subpath.join('.'));
+      error("subpath error for id: " + id + " and path: " + subpath.join("."));
     }
 
     if (nestedVal instanceof Function) {
-      return nestedVal.bind(parent)
+      return nestedVal.bind(parent);
     }
     return nestedVal;
   }
@@ -56,11 +55,11 @@ export class Context {
    * Set the value of id in the context.
    * @param {string} id The identifier to set.
    * @param {any} val The value to set.
-   * @param {boolean} Whether to treat the identifier as a variable or 
+   * @param {boolean} Whether to treat the identifier as a variable or
    *     constant binding.
    * @param {string[]} subpath Nested subpath.
    * @return {any} The value that was set.
-   */ 
+   */
   set(id, val, constant = false, subpath = undefined) {
     if (this._constants.has(id)) {
       if (!constant) {
@@ -69,18 +68,18 @@ export class Context {
         delete this.env[id];
       }
     }
-    
+
     if (constant) {
       this._constants.add(id);
     }
 
     if (!subpath || subpath.length === 0) {
-       this.env[id] = val;
-       return val;
+      this.env[id] = val;
+      return val;
     }
 
     if (!(id in this.env)) {
-      error('nested set - no top level parent: ' + id);
+      error("nested set - no top level parent: " + id);
     }
 
     setNested(this.env[id], subpath, val);
@@ -88,13 +87,12 @@ export class Context {
   }
 }
 
-
 /**
  * Search for a nested path in the object outer.
  * @param {object} outer The context to search in.
  * @param {string[]} path The array of strings to search with.
  * @return {[any, object]} A tuple where the first element is the asked for
- *     value or undefined. The second element is the direct parent which is 
+ *     value or undefined. The second element is the direct parent which is
  *     helpful for binding 'this' if the value is a function.
  */
 function nested(outer, path) {
@@ -108,13 +106,12 @@ function nested(outer, path) {
   return [parent[path[path.length - 1]], parent];
 }
 
-
 /**
  * Set for a nested path in the object outer.
  * @param {object} outer The context to search in.
  * @param {string[]} path The array of strings to search with.
  * @return {[any, object]} A tuple where the first element is the asked for
- *     value or undefined. The second element is the direct parent which is 
+ *     value or undefined. The second element is the direct parent which is
  *     helpful for binding 'this' if the value is a function.
  */
 function setNested(obj, path, value) {

--- a/src/lang/index.mjs
+++ b/src/lang/index.mjs
@@ -1,69 +1,77 @@
 /**
  * @file A lisp dialect.
  */
-import { Type } from './types.mjs';
-import { Context } from './context.mjs';
-import { tokenize } from './tokenize.mjs';
-import { parse } from './parse.mjs';
-import { interpret, core, extensions } from './interpret.mjs';
-import { prettyPrint } from './pretty-print.mjs';
-import { utils, math, lists, prng } from './lib.mjs';
+import { TokenType } from "./token.mjs";
+import { SlopType, SlopVal } from "./types.mjs";
+import { Context } from "./context.mjs";
+import { tokenize } from "./tokenize.mjs";
+import { parse } from "./parse.mjs";
+import { interpret, core, extensions } from "./interpret.mjs";
+import { prettyPrint } from "./pretty-print.mjs";
+import { utils, math, lists, prng } from "./lib.mjs";
 
 export const SpecialWords = {
-  nil: undefined,
+  nil: SlopVal.nil(),
+  // Is `null` a valid slop val? Should we get rid of this in favor of `nil`?
+  // Right now we have no explicit support for `null` in the SLOP type system
   null: null,
-  empty: [],
-  true: true,
-  false: false,
-  else: true
+  empty: SlopVal.list([]),
+  true: SlopVal.bool(true),
+  false: SlopVal.bool(false),
+  else: SlopVal.bool(true),
 };
 
 export const lib = { ...utils, ...math, ...lists, ...prng };
 
-export { Type, Context, tokenize, parse, interpret, prettyPrint, extensions };
+export {
+  TokenType,
+  SlopType,
+  Context,
+  tokenize,
+  parse,
+  interpret,
+  prettyPrint,
+  extensions,
+};
 
 /**
  * Keywords for syntax highlight.
  * @type {string[]}
- */ 
+ */
 export const keywords = Object.keys({ ...core, ...SpecialWords });
 
 /**
  * Read source text and return a tokens array and a syntax tree.
  * @param {string}
- */ 
+ */
 export function read(source) {
   const tokens = tokenize(source);
   try {
     const tree = parse(tokens);
-    return { ok: true, tokens, tree }
+    return { ok: true, tokens, tree };
   } catch (e) {
     return { ok: false, tokens, error: e };
   }
 }
-
 
 export function run(source, context) {
   const tokens = tokenize(source);
   try {
     const tree = parse(tokens);
 
-    console.log(tree, tokens)
-    
+    console.log(tree, tokens);
+
     let result = null;
-    
+
     for (let expression of tree) {
       result = interpret(expression, context);
     }
 
     return { ok: true, result, tree, tokens };
-
   } catch (e) {
-
-    return { ok: false, error: e, tokens};
+    return { ok: false, error: e, tokens };
   }
 }
-
 
 export function registerExtension(name, fn) {
   if (!(name in extensions)) {

--- a/src/lang/pretty-print.mjs
+++ b/src/lang/pretty-print.mjs
@@ -1,60 +1,64 @@
-import { Type } from './types.mjs';
+import { TokenType } from "./token.mjs";
 
-function isObj (any) {
-  return (typeof any === 'object') && !Array.isArray(any) && any !== null; 
+function isObj(any) {
+  return typeof any === "object" && !Array.isArray(any) && any !== null;
 }
 
 export function prettyPrint(item) {
-  if (item === undefined){
-    return 'nil';
-  }
-  
-  if (item === null){
-    return 'null';
+  if (item === undefined) {
+    return "nil";
   }
 
-  if (typeof item === 'number'){
+  if (item === null) {
+    return "null";
+  }
+
+  if (typeof item === "number") {
     return item;
   }
 
-
-  if (Type.valid(item)){
-    return Type.getString(item);
+  if (TokenType.valid(item)) {
+    return TokenType.getString(item);
   }
 
   if (item.type !== undefined) {
-    if (item.type === Type.LIST) {
-      return `${Type.getString(Type.LIST)} – ${prettyPrint(item.elements)}`;
+    if (item.type === TokenType.LIST) {
+      return `${TokenType.getString(TokenType.LIST)} – ${prettyPrint(
+        item.elements
+      )}`;
     }
 
-    if (item.type === Type.VEC) {
-      return `${Type.getString(Type.VEC)} – ${prettyPrint(item.elements)}`;
+    if (item.type === TokenType.VEC) {
+      return `${TokenType.getString(TokenType.VEC)} – ${prettyPrint(
+        item.elements
+      )}`;
     }
 
-    if (item.type === Type.DICT) {
-      return `${Type.getString(Type.DICT)} – ${prettyPrint(item.dict)}`;
+    if (item.type === TokenType.DICT) {
+      return `${TokenType.getString(TokenType.DICT)} – ${prettyPrint(
+        item.dict
+      )}`;
     }
 
-    return `${Type.getString(item.type)} – ${item.val}`;
+    return `${TokenType.getString(item.type)} – ${item.val}`;
   }
 
   if (isObj(item)) {
-    return `{ ${Object.entries(item).map(x => {
-      return `${x[0]} : ${prettyPrint(x[1])}`
-    }).join(', ')} }`;
+    return `{ ${Object.entries(item)
+      .map((x) => {
+        return `${x[0]} : ${prettyPrint(x[1])}`;
+      })
+      .join(", ")} }`;
   }
-  
+
   if (item instanceof Function)
-    return `{ Function : ${item.funcName || 'anon'} }`;
+    return `{ Function : ${item.funcName || "anon"} }`;
 
-  if (Array.isArray(item))
-    return `[ ${item.map(prettyPrint).join(', ')} ]`;
+  if (Array.isArray(item)) return `[ ${item.map(prettyPrint).join(", ")} ]`;
 
-  if (typeof item === "string")
-    return `"${item}"`;
+  if (typeof item === "string") return `"${item}"`;
 
-  if (item._customFormat)
-    return item._customFormat()
+  if (item._customFormat) return item._customFormat();
 
   return JSON.stringify(item);
 }

--- a/src/lang/test.mjs
+++ b/src/lang/test.mjs
@@ -1,6 +1,6 @@
 /**
  * @file Tests.
- */ 
+ */
 
 function _equal(a, b) {
   if (Array.isArray(a)) return _arrayEqual(a, b);
@@ -17,27 +17,26 @@ function _arrayEqual(a, b) {
 }
 
 const ansi = {
-  red: '\x1b[31m',
-  green: '\x1b[32m',
-  reset: '\x1b[0m',
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  reset: "\x1b[0m",
 };
 
 function fail(msg) {
-  if (typeof process === 'object') {
-    console.log(ansi.red + msg + ansi.reset);  
+  if (typeof process === "object") {
+    console.log(ansi.red + msg + ansi.reset);
   } else {
-    console.log('%c' + msg, 'color: red');
+    console.log("%c" + msg, "color: red");
   }
 }
 
 function pass(msg) {
-  if (typeof process === 'object') {
-    console.log(ansi.green + msg + ansi.reset);  
+  if (typeof process === "object") {
+    console.log(ansi.green + msg + ansi.reset);
   } else {
-    console.log('%c' + msg, 'color: green');
+    console.log("%c" + msg, "color: green");
   }
 }
-
 
 const assert = {
   equal: function (got, expected, message) {
@@ -45,11 +44,11 @@ const assert = {
       fail(`𐄂 ${message}\n\tGot: ${got}\n\tExpected: ${expected}`);
       return;
     }
-    pass('✓ ' + message);
-  }
-}
+    pass("✓ " + message);
+  },
+};
 
-export function Test (desc, fn) {
-  console.log('\nTest Unit:', desc);
+export function Test(desc, fn) {
+  console.log("\nTest Unit:", desc);
   fn(assert);
 }

--- a/src/lang/tiny-lisp.test.mjs
+++ b/src/lang/tiny-lisp.test.mjs
@@ -1,8 +1,8 @@
-import { lib } from './index.mjs';
+import { lib } from "./index.mjs";
 
-const lang = await import('./index.mjs');
-const toJS = await import('./extensions/to-js.mjs');
-const { Test } = await import('./test.mjs');
+const lang = await import("./index.mjs");
+const toJS = await import("./extensions/to-js.mjs");
+const { Test } = await import("./test.mjs");
 
 const test = (src, ctx = {}) => {
   try {
@@ -13,153 +13,226 @@ const test = (src, ctx = {}) => {
       res = lang.interpret(expr, context);
     }
     return res;
-  } catch {
+  } catch (err) {
     return null;
   }
-}
+};
 
-
-Test('Basics', (assert) => {
-  assert.equal(test(''), null, 'Empty string -> null');
-  assert.equal(test('10'), 10, 'Integer atom');
-  assert.equal(test('"lang"'), "lang", 'String atom');
-  assert.equal(test('[10]'), [10], '1 elem list');
-  assert.equal(test('[10 60 30]'), [10, 60, 30], '3 elem list');
-  assert.equal(test('[20] [60]'), [60], '2 lists');
-  assert.equal(test('(0- sa'), null, 'Syntax error -> null');
+Test("Basics", (assert) => {
+  assert.equal(test(""), undefined, "Empty string -> null");
+  assert.equal(test("10"), 10, "Integer atom");
+  assert.equal(test('"lang"'), "lang", "String atom");
+  assert.equal(test("(list 10)"), [10], "1 elem list");
+  assert.equal(test("(list 10 60 30)"), [10, 60, 30], "3 elem list");
+  assert.equal(test("(list 20) (list 60)"), [60], "2 lists");
+  assert.equal(test("(0- sa"), undefined, "Syntax error -> null");
 });
 
-
-Test('Lambdas', (assert) => {
+Test("Lambdas", (assert) => {
   let src;
-  
+
   src = `(fn [x] x)`;
   const type = typeof test(src);
-  assert.equal(type, 'function', 'Lambda returns js function');
+  assert.equal(type, "function", "Lambda returns js function");
 
   src = `((fn [x] x) 10)`;
-  assert.equal(test(src), 10, 'Immediately invoked identity lambda');
+  assert.equal(test(src), 10, "Immediately invoked identity lambda");
 });
 
-
-Test('Define', (assert) => {
+Test("Define", (assert) => {
   let src;
 
   src = `(def a 10)`;
-  assert.equal(test(src), 10, 'Define numeric constant: returns val');
-  
-  src = `(def a 10) (def b 20) a`
-  assert.equal(test(src), 10, 'Lookup numeric constant');
+  assert.equal(test(src), 10, "Define numeric constant: returns val");
 
-  src = `(def a 10) (def b 20) [a b]`
-  assert.equal(test(src), [10, 20], 'Lookup 2 numeric constants');
+  src = `(def a 10) (def b 20) a`;
+  assert.equal(test(src), 10, "Lookup numeric constant");
 
-  src = `(def i (fn [x] [x])) (i "yo")`;
-  assert.equal(test(src), ["yo"], 'Identity lambda - as list');
+  src = `(def a 10) (def b 20) (list a b)`;
+  assert.equal(test(src), [10, 20], "Lookup 2 numeric constants");
+
+  src = `(def i (fn [x] (list x))) (i "yo")`;
+  assert.equal(test(src), ["yo"], "Identity lambda - as list");
 
   src = `(def i (fn [x] x)) (i 5)`;
-  assert.equal(test(src), 5, 'Identity lambda - no list');
+  assert.equal(test(src), 5, "Identity lambda - no list");
 
-  src = `(defn concat [x] [x x]) (concat 30)`;
-  assert.equal(test(src), [30, 30], 'Defn syntax sugar');
+  src = `(defn concat [x] (list x x)) (concat 30)`;
+  assert.equal(test(src), [30, 30], "Defn syntax sugar");
 });
 
-
-Test('Js funcs in global scope', (assert) => {
+Test("Js funcs in global scope", (assert) => {
   let src, context;
   context = {
-    sum: (...list) => list.reduce((a, b) => a + b, 0)
+    sum: (...list) => list.reduce((a, b) => a + b, 0),
   };
-  
-  assert.equal(context.sum(1, 2), 3, 'Js sum');
+
+  assert.equal(context.sum(1, 2), 3, "Js sum");
 
   src = `(sum 1 2 3 4)`;
-  assert.equal(test(src, context), 10, 'Js sum in lisp');
+  assert.equal(test(src, context), 10, "Js sum in lisp");
 });
 
-
-Test('Core: if', (assert) => {
+Test("Core: if", (assert) => {
   let src;
 
   src = `(if true 8 0)`;
-  assert.equal(test(src), 8, 'If with 1 : pass clause');
+  assert.equal(test(src), 8, "If with 1 : pass clause");
 
   src = `(if false 8 0)`;
-  assert.equal(test(src), 0, 'If with 1 : fail clause');
+  assert.equal(test(src), 0, "If with 1 : fail clause");
 
   src = `(if false 8)`;
-  assert.equal(test(src), null, 'Malformed if');
+  assert.equal(test(src), null, "Malformed if");
 });
 
+Test("Core: let", (assert) => {
+  let src;
 
-Test('Funcs as params', (assert) => {
+  src = `(let [(foo "bar")] foo)`;
+  assert.equal(test(src), "bar", "basic let");
+
+  src = `(let [(a "A") (b "B")] (list a b))`;
+  assert.equal(test(src), ["A", "B"], "multi-binding let");
+});
+
+Test("Core: cond", (assert) => {
+  let src;
+
+  src = `(cond (true "true") (false "false"))`;
+  assert.equal(test(src), "true", "basic cond");
+
+  src = `(cond (true "true") (true "also true"))`;
+  assert.equal(test(src), "true", "cond returns first `true` result");
+
+  src = `(cond (false "false"))`;
+  assert.equal(test(src), undefined, "cond returns nil on no match");
+
+  src = `(cond (false "false") (else "else"))`;
+  assert.equal(test(src), "else", "cond supports `else` branch");
+});
+
+Test("Core: quote", (assert) => {
+  let src;
+
+  src = `(quote 1 2)`;
+  assert.equal(test(src), null, "invalid quote");
+
+  src = `(def foo 1) (quote foo)`;
+  assert.equal(test(src), "foo", "valid quote");
+});
+
+Test("Core: eval", (assert) => {
+  let src;
+
+  const context = {
+    "+": (a, b) => a + b,
+  };
+  const _test = (expr) => test(expr, context);
+
+  src = `(eval (quote (+ 1 2)))`;
+  assert.equal(_test(src), 3, "eval with quote");
+
+  src = `(let [(dbl (fn [x] (+ x x)))] (eval (quote (dbl 2))))`;
+  assert.equal(_test(src), 4, "eval with quote and binding");
+});
+
+Test("Funcs as params", (assert) => {
   let src, context;
 
   context = {
-    join: (...list) => list.join('')
+    join: (...list) => list.join(""),
   };
 
   src = `
-    (defn greet (greeting) 
+    (defn greet (greeting)
        (fn (name) (join greeting " " name)))
 
     ((greet "hey") "there")
   `.trim();
-  
-  assert.equal(test(src, context), 'hey there', 'Function as param');
+
+  assert.equal(test(src, context), "hey there", "Function as param");
 });
 
-
-
-Test('Types', (assert) => {
+Test("Types", (assert) => {
   const context = {
-    '+': (a, b) => a + b,
+    "+": (a, b) => a + b,
   };
 
   function wrapTestWithSymbolCheck(output, expected, message) {
-    const o = lang.Type.getString(output);
-    const e = lang.Type.getString(expected);
+    const o = lang.SlopType.getString(output);
+    const e = lang.SlopType.getString(expected);
     assert.equal(o, e, message);
   }
 
-  wrapTestWithSymbolCheck(test('(type nil)'), lang.Type.NIL, 'nil');
-  wrapTestWithSymbolCheck(test('(type 1)'), lang.Type.NUM, 'num');
-  wrapTestWithSymbolCheck(test('(type "h")'), lang.Type.STR, 'str');
-  wrapTestWithSymbolCheck(test('(type (+ 1 2))', context), lang.Type.NUM, 'function -> num');
-  wrapTestWithSymbolCheck(test('(type {:a 1})'), lang.Type.DICT, 'dict literal');
-  wrapTestWithSymbolCheck(test('(type {})'), lang.Type.DICT, 'dict literal empty');
-  wrapTestWithSymbolCheck(test('(type ())'), lang.Type.NIL, 'empty tuple -> nil');
-  wrapTestWithSymbolCheck(test('(type [])'), lang.Type.VEC, 'empty vec');
-  wrapTestWithSymbolCheck(test('(type [1 2 3])'), lang.Type.VEC, 'vec literal');
-  wrapTestWithSymbolCheck(test('(type :a)'), lang.Type.KEY, 'key');
-  wrapTestWithSymbolCheck(test('(type :a-b)'), lang.Type.KEY, 'key with dash');
-  wrapTestWithSymbolCheck(test('(type (fn (x) x))'), lang.Type.FUNC, 'lambda');
+  wrapTestWithSymbolCheck(test("(type nil)"), lang.SlopType.NIL, "nil");
+  wrapTestWithSymbolCheck(test("(type 1)"), lang.SlopType.NUM, "num");
+  wrapTestWithSymbolCheck(test('(type "h")'), lang.SlopType.STR, "str");
+  wrapTestWithSymbolCheck(
+    test("(type (+ 1 2))", context),
+    lang.SlopType.NUM,
+    "function -> num"
+  );
+  wrapTestWithSymbolCheck(
+    test("(type {:a 1})"),
+    lang.SlopType.DICT,
+    "dict literal"
+  );
+  wrapTestWithSymbolCheck(
+    test("(type {})"),
+    lang.SlopType.DICT,
+    "dict literal empty"
+  );
+  wrapTestWithSymbolCheck(
+    test("(type ())"),
+    lang.SlopType.NIL,
+    "empty tuple -> nil"
+  );
+  wrapTestWithSymbolCheck(
+    test("(type (list))"),
+    lang.SlopType.LIST,
+    "empty vec"
+  );
+  wrapTestWithSymbolCheck(
+    test("(type (list 1 2 3))"),
+    lang.SlopType.LIST,
+    "list literal"
+  );
+  wrapTestWithSymbolCheck(test("(type :a)"), lang.SlopType.KEY, "key");
+  wrapTestWithSymbolCheck(
+    test("(type :a-b)"),
+    lang.SlopType.KEY,
+    "key with dash"
+  );
+  wrapTestWithSymbolCheck(
+    test("(type (fn (x) x))"),
+    lang.SlopType.FUNC,
+    "lambda"
+  );
 });
 
-
-Test('toJS string-based compile', (assert) => {
-
+Test("toJS string-based compile", (assert) => {
   const exprs = [
     {
-      lisp: '(+ 1 2)',
-      js: '(1 + 2)'
+      lisp: "(+ 1 2)",
+      js: "(1 + 2)",
     },
     {
-      lisp: '(+ (* 4 3 2) (/ 6 10 2))',
-      js: '((4 * 3 * 2) + (6 / 10 / 2))'
+      lisp: "(+ (* 4 3 2) (/ 6 10 2))",
+      js: "((4 * 3 * 2) + (6 / 10 / 2))",
     },
     {
       lisp: '(if (>= 4 0) "cool" 0)',
       js: '((4 >= 0) ? "cool" : 0)',
-    }, 
+    },
     {
-      lisp: '(min x y z)',
-      js: 'Math.min(x, y, z)'
-    }, 
+      lisp: "(min x y z)",
+      js: "Math.min(x, y, z)",
+    },
     {
-      lisp: '(1 2 3 4 5)',
-      js: '[1, 2, 3, 4, 5]'
-    }
+      lisp: "(1 2 3 4 5)",
+      js: "[1, 2, 3, 4, 5]",
+    },
   ];
 
   for (let expr of exprs) {

--- a/src/lang/token.mjs
+++ b/src/lang/token.mjs
@@ -1,0 +1,54 @@
+/**
+ * Tokens we encounter during reading.
+ */
+export const TokenType = {
+  L_PAREN: Symbol("L_PAREN"),
+  R_PAREN: Symbol("R_PAREN"),
+  L_BRACE: Symbol("L_BRACE"),
+  R_BRACE: Symbol("R_BRACE"),
+  L_BRACKET: Symbol("L_BRACKET"),
+  R_BRACKET: Symbol("R_BRACKET"),
+  COMMENT: Symbol("COMMENT"),
+  NUM: Symbol("NUM"),
+  STR: Symbol("STR"),
+  KEY: Symbol("KEY"),
+  SYMBOL: Symbol("SYMBOL"),
+  EOF: Symbol("EOF"),
+};
+
+const _symbolToString = new Map(
+  Object.entries(TokenType).map(([k, v]) => [v, k])
+);
+
+TokenType.getString = function (symbol) {
+  return _symbolToString.get(symbol);
+};
+
+TokenType.valid = function (symbol) {
+  return _symbolToString.has(symbol);
+};
+
+Object.freeze(TokenType);
+
+class Token {
+  constructor(type, val, str, range, line, col) {
+    this.type = type;
+    this.val = val;
+    this.str = str;
+    this.range = range;
+    this.line = line;
+    this.col = col;
+  }
+}
+
+export class SymbolToken extends Token {
+  constructor(val, str, range, line, col, subpath = undefined) {
+    super(TokenType.SYMBOL, val, str, range, line, col);
+    this.subpath = subpath;
+  }
+}
+
+/**
+ * Token constructor
+ */
+export const token = (...args) => new Token(...args);

--- a/src/lang/types.mjs
+++ b/src/lang/types.mjs
@@ -1,37 +1,256 @@
 /**
- * Types enum to be shared by the reading, interpreting and highlighting 
- * process.
+ * Built-in runtime data types.
  */
-export const Type = {
-  L_PAREN: Symbol('L_PAREN'),
-  R_PAREN: Symbol('R_PAREN'),
-  L_BRACE: Symbol('L_BRACE'),
-  R_BRACE: Symbol('R_BRACE'),
-  L_BRACKET: Symbol('L_BRACKET'),
-  R_BRACKET: Symbol('R_BRACKET'),
-  COMMENT: Symbol('COMMENT'),
-  EOF: Symbol('EOF'),
-  
-  NIL: Symbol('NIL'),
-  NUM: Symbol('NUM'),
-  STR: Symbol('STR'),
-  KEY: Symbol('KEY'),
-  IDENTIFIER: Symbol('IDENTIFIER'),
-  LIST: Symbol('LIST'),
-  DICT: Symbol('DICT'),
-  VEC: Symbol('VEC'),
-  FUNC: Symbol('FUNC'),
-  UNKNOWN: Symbol('UNKNOWN'),
+export const SlopType = {
+  NIL: Symbol("NIL"),
+  NUM: Symbol("NUM"),
+  STR: Symbol("STR"),
+  KEY: Symbol("KEY"),
+  SYMBOL: Symbol("SYMBOL"),
+  LIST: Symbol("LIST"),
+  DICT: Symbol("DICT"),
+  VEC: Symbol("VEC"),
+  FUNC: Symbol("FUNC"),
+  UNKNOWN: Symbol("UNKNOWN"),
 };
 
-const _symbolToString = new Map(Object.entries(Type).map(([k, v]) => [v, k]));
+const _symbolToString = new Map(
+  Object.entries(SlopType).map(([k, v]) => [v, k])
+);
 
-Type.getString = function (symbol) {
+SlopType.getString = function (symbol) {
   return _symbolToString.get(symbol);
-}
+};
 
-Type.valid = function (symbol){
+SlopType.valid = function (symbol) {
   return _symbolToString.has(symbol);
+};
+
+Object.freeze(SlopType);
+
+/**
+ * Constructs homoiconic shared types from plain Js types.
+ */
+export const SlopVal = {
+  nil() {
+    return undefined;
+  },
+
+  bool(b) {
+    if (typeof b !== "boolean") {
+      throw new Error("Expected boolean to construct boolean");
+    }
+    return b;
+  },
+
+  symbol(s, subpath = undefined) {
+    if (typeof s !== "string") {
+      throw new Error("Expected string to construct symbol");
+    }
+    return new SlopSymbol(s, subpath);
+  },
+
+  string(s) {
+    if (typeof s !== "string") {
+      throw new Error("Expected string to construct string literal");
+    }
+    return new SlopString(s);
+  },
+
+  key(s) {
+    if (typeof s !== "string") {
+      throw new Error("Expected string to construct key");
+    }
+    return new SlopKey(s);
+  },
+
+  num(n) {
+    if (typeof n !== "number") {
+      throw new Error("Expected number to construct number");
+    }
+    return n;
+  },
+
+  list(xs) {
+    if (!Array.isArray(xs)) {
+      throw new Error("Expected array to construct list");
+    }
+    return xs;
+  },
+
+  dict(map) {
+    if (map == null || !map?.constructor === Object) {
+      throw new Error("Expexted plain JS object to construct dict");
+    }
+    return map;
+  },
+
+  fn(fn, name = undefined) {
+    if (typeof fn !== "function") {
+      throw new Error("Expected function to construct function");
+    }
+    if (name) {
+      fn.funcName = name;
+    }
+    return fn;
+  },
+};
+
+Object.freeze(SlopVal);
+
+/**
+ * SLOP bool APIs
+ */
+export const SlopBool = {
+  isTrue(b) {
+    return !!b;
+  },
+
+  isFalse(b) {
+    return !SlopBool.isTrue(b);
+  },
+};
+
+/**
+ * SLOP list APIs
+ */
+export const SlopList = {
+  first(l) {
+    return l[0];
+  },
+
+  rest(l) {
+    return l.slice(1);
+  },
+
+  take(l, n) {
+    return l.slice(0, n);
+  },
+
+  decap(l) {
+    const [first, ...rest] = l;
+    return [first, rest];
+  },
+
+  split(l, n) {
+    return [l.slice(0, n), l.slice(n)];
+  },
+
+  map(l, fn) {
+    return l.map(fn);
+  },
+
+  forEach(l, fn) {
+    l.forEach(fn);
+  },
+
+  *iter(l) {
+    for (let i = 0; i < SlopList.len(l); i++) {
+      yield SlopList.at(l, i);
+    }
+  },
+
+  reduce(l, fn, init = SlopVal.nil()) {
+    return l.reduce(fn, init);
+  },
+
+  at(l, i) {
+    return l[i];
+  },
+
+  len(l) {
+    return l.length;
+  },
+};
+
+/**
+ * SLOP dict APIs
+ */
+export const SlopDict = {
+  get(dict, key) {
+    return dict[key];
+  },
+
+  entries(dict) {
+    return SlopVal.list(Object.entries(dict));
+  },
+
+  mapVals(dict, fn) {
+    return SlopDict.mapEntries(dict, ([key, val]) => [key, fn(val)]);
+  },
+
+  mapEntries(dict, fn) {
+    const newDict = {};
+    for (let entry in Object.entries(dict)) {
+      const [newKey, newVal] = fn(entry);
+      newDict[newKey] = newVal;
+    }
+    return SlopVal.dict(newDict);
+  },
+};
+
+/**
+ * Slop function APIs
+ */
+export const SlopFn = {
+  apply(fn, args) {
+    return fn(...args);
+  },
+};
+
+/**
+ * Predicates for getting types of SLOP values
+ */
+export const SlopPred = {
+  isNil: (val) => val === undefined,
+
+  isBool: (val) => typeof val === "boolean",
+
+  isSymbol: (val) => val?.constructor?.name === "SlopSymbol",
+
+  isString: (val) => val?.constructor?.name === "SlopString",
+
+  isKey: (val) => val?.constructor?.name === "SlopKey",
+
+  isNum: (val) => typeof val === "number",
+
+  isList: Array.isArray,
+
+  isDict: (val) => val?.constructor === Object,
+
+  isFn: (val) => typeof val === "function",
+};
+
+export function isAtom(val) {
+  return [
+    SlopPred.isNil,
+    SlopPred.isBool,
+    SlopPred.isSymbol,
+    SlopPred.isString,
+    SlopPred.isKey,
+    SlopPred.isNum,
+  ].some((p) => p(val));
 }
 
-Object.freeze(Type);
+Object.freeze(SlopPred);
+
+class SlopText extends String {}
+
+class SlopSymbol extends SlopText {
+  constructor(val, subpath = undefined) {
+    super(val);
+    this.subpath = subpath;
+  }
+}
+
+class SlopString extends SlopText {
+  constructor(val) {
+    super(val);
+  }
+}
+
+class SlopKey extends SlopText {
+  constructor(val) {
+    super(val);
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,23 +1,21 @@
 import * as lisp from "./lang/index.mjs";
-import * as themes from './themes.js';
-import { Canvas } from './canvas.js';
-import { CodeEditor } from './components/code-editor/code-editor.js';
+import * as themes from "./themes.js";
+import { Canvas } from "./canvas.js";
+import { CodeEditor } from "./components/code-editor/code-editor.js";
 
 // Import the the to-js compiler extensions.
-import './lang/extensions/to-js.mjs';
+import "./lang/extensions/to-js.mjs";
 
 const THEME = themes.xcodeDark;
 
-const imagesBySource = window.imagesBySource = {};
-const files = window.files = [];
+const imagesBySource = (window.imagesBySource = {});
+const files = (window.files = []);
 
 function ctx(editor = null, viewport = null) {
-
   // Add lisp to the scope.
   const scope = Object.assign({}, lisp.lib);
 
   if (editor) {
-
     // Add lisp to the scope.
     Object.assign(scope, {
       print: (...items) => {
@@ -29,11 +27,10 @@ function ctx(editor = null, viewport = null) {
     if (viewport) scope.viewport = viewport;
 
     Object.assign(scope, {
-
       // Add the canvas stuff to the scope.
       Canvas: Canvas,
-      '->Canvas': (...args) => new Canvas(...args),
-      'make-canvas': (width, height, label) => {
+      "->Canvas": (...args) => new Canvas(...args),
+      "make-canvas": (width, height, label) => {
         return new Canvas(width, height, label);
       },
 
@@ -44,36 +41,33 @@ function ctx(editor = null, viewport = null) {
         if (viewport) {
           viewport.artboards.push({
             canvas: canvas.canvas,
-            position: [x, y]
-          })
+            position: [x, y],
+          });
         }
       },
 
       // Open a canvas in a new tab.
-      'open-new': (canvas) => {
+      "open-new": (canvas) => {
         const url = canvas.canvas.toDataURL();
-        fetch(url).then(async res => {
+        fetch(url).then(async (res) => {
           const blob = await res.blob();
           const handle = URL.createObjectURL(blob);
           window.open(handle);
-        })
+        });
         return canvas;
       },
 
-
       now: () => performance.now(),
 
-
-
-      '@color': (x) => {
+      "@color": (x) => {
         return x;
       },
 
-      '@slider': (x) => {
+      "@slider": (x) => {
         return x;
       },
 
-      'load-img': (url) => {
+      "load-img": (url) => {
         if (imagesBySource[url]) {
           const img = imagesBySource[url];
           const cnvs = new Canvas(img.width, img.height);
@@ -86,20 +80,20 @@ function ctx(editor = null, viewport = null) {
         img.crossOrigin = "Anonymous";
         img.onload = () => {
           imagesBySource[url] = img;
-          window.dispatchEvent(new Event('image-load'));
-        }
+          window.dispatchEvent(new Event("image-load"));
+        };
         img.onerror = (e) => {
-          if (editor) editor.error('Img load error: ' + url);
-          console.error(e)
-        }
+          if (editor) editor.error("Img load error: " + url);
+          console.error(e);
+        };
 
         return new Canvas(1, 1);
       },
 
       files: files,
 
-      '#JS': (str) => eval(str),
-    })
+      "#JS": (str) => eval(str),
+    });
 
     return new lisp.Context(scope);
   }
@@ -113,16 +107,13 @@ for (let word of Object.keys(lisp.extensions)) {
   globals.add(word);
 }
 
-window.addEventListener('DOMContentLoaded', () => {
-
+window.addEventListener("DOMContentLoaded", () => {
   /** @type {CodeEditor} */
-  const editor = document.getElementById('editor');
+  const editor = document.getElementById("editor");
 
-
-  const viewport = window.viewport = document.getElementById('viewport');
-  const importer = document.getElementById('file-import');
-  const opener = document.getElementById('file-open');
-
+  const viewport = (window.viewport = document.getElementById("viewport"));
+  const importer = document.getElementById("file-import");
+  const opener = document.getElementById("file-open");
 
   themes.applyTheme(THEME, document.documentElement, editor, viewport);
 
@@ -141,82 +132,80 @@ window.addEventListener('DOMContentLoaded', () => {
 
     if (ok) {
       viewport.draw();
-      if (useLog)
-        editor.print(lisp.prettyPrint(result));
+      if (useLog) editor.print(lisp.prettyPrint(result));
     } else {
       editor.error(error);
       console.error(error);
     }
-  }
+  };
 
   editor.setSyntax({
     tokenize: lisp.tokenize,
     keywords: globals,
-    comment: '#',
+    comment: "#",
     tabSize: 2,
   });
 
   // Eval on control+enter
-  editor.mapkey('ctrl+enter', evalAll);
+  editor.mapkey("ctrl+enter", evalAll);
 
   // Eval when an imahge reloads.
-  window.addEventListener('image-load', evalAll);
+  window.addEventListener("image-load", evalAll);
 
-  editor.mapkey('tab', () => editor.indent());
-  editor.mapkey('shift+tab', () => editor.indent(true));
-  editor.mapkey('meta+z', (e) => editor.undo(e), false);
-  editor.mapkey('ctrl+-', () => editor.zoom(-0.1));
-  editor.mapkey('ctrl+=', () => editor.zoom(+0.1));
-  editor.mapkey('meta+s', () => editor.save('MAIN'));
-  editor.mapkey('ctrl+c', () => editor.clearLog());
-  editor.mapkey('meta+/', () => editor.comment());
-  editor.mapkey('ctrl+i', () => importer.click());
+  editor.mapkey("tab", () => editor.indent());
+  editor.mapkey("shift+tab", () => editor.indent(true));
+  editor.mapkey("meta+z", (e) => editor.undo(e), false);
+  editor.mapkey("ctrl+-", () => editor.zoom(-0.1));
+  editor.mapkey("ctrl+=", () => editor.zoom(+0.1));
+  editor.mapkey("meta+s", () => editor.save("MAIN"));
+  editor.mapkey("ctrl+c", () => editor.clearLog());
+  editor.mapkey("meta+/", () => editor.comment());
+  editor.mapkey("ctrl+i", () => importer.click());
 
-  viewport.mapkey('ctrl+-', () => viewport.zoom(-0.1));
-  viewport.mapkey('ctrl+=', () => viewport.zoom(+0.1));
-  viewport.mapkey('ctrl+l', () => viewport.pan(+50, 0));
-  viewport.mapkey('ctrl+h', () => viewport.pan(-50, 0));
-  viewport.mapkey('ctrl+k', () => viewport.pan(0, -50));
-  viewport.mapkey('ctrl+j', () => viewport.pan(0, 50));
+  viewport.mapkey("ctrl+-", () => viewport.zoom(-0.1));
+  viewport.mapkey("ctrl+=", () => viewport.zoom(+0.1));
+  viewport.mapkey("ctrl+l", () => viewport.pan(+50, 0));
+  viewport.mapkey("ctrl+h", () => viewport.pan(-50, 0));
+  viewport.mapkey("ctrl+k", () => viewport.pan(0, -50));
+  viewport.mapkey("ctrl+j", () => viewport.pan(0, 50));
 
-  importer.addEventListener('change', e => {
+  importer.addEventListener("change", (e) => {
     for (let file of e.target.files) {
       const reader = new FileReader();
       reader.readAsDataURL(file);
-      reader.onloadend = e => {
+      reader.onloadend = (e) => {
         const img = new Image();
         img.src = reader.result;
-        editor.print('Loaded: ' + file.name);
+        editor.print("Loaded: " + file.name);
         imagesBySource[file.name] = img;
         files.push(file.name);
       };
     }
   });
 
-
-  opener.addEventListener('change', e => {
+  opener.addEventListener("change", (e) => {
     console.log(e);
     for (let file of e.target.files) {
       const reader = new FileReader();
       reader.readAsText(file);
-      reader.onloadend = e => {
+      reader.onloadend = (e) => {
         editor.source.value = reader.result;
         editor.update();
-        editor.save('MAIN');
+        editor.save("MAIN");
       };
     }
   });
 
-  document.getElementById('save-text').addEventListener('click', e => {
-    const blob = new Blob([editor.text], { type: 'text/plain' });
+  document.getElementById("save-text").addEventListener("click", (e) => {
+    const blob = new Blob([editor.text], { type: "text/plain" });
 
     // Create a URL for the Blob
     const url = URL.createObjectURL(blob);
 
     // Create an anchor element
-    const link = document.createElement('a');
+    const link = document.createElement("a");
     link.href = url;
-    link.download = 'script.slop';
+    link.download = "script.slop";
 
     link.click();
   });
@@ -224,13 +213,13 @@ window.addEventListener('DOMContentLoaded', () => {
   let lastChange = Date.now();
   const threshTime = 60;
 
-  editor.listen(editor, 'mousemove', (e) => {
+  editor.listen(editor, "mousemove", (e) => {
     if (e.metaKey) {
       const [token, index] = editor.tokenAt(editor.caretPosition);
 
-      if (token.type === lisp.Type.NUM) {
+      if (token.type === lisp.TokenType.NUM) {
         const n = Date.now();
-        const update = (n - lastChange) > threshTime;
+        const update = n - lastChange > threshTime;
         if (update) {
           lastChange = n;
           evalAll(false);
@@ -243,15 +232,14 @@ window.addEventListener('DOMContentLoaded', () => {
         }
 
         let newVal = token.val + delta;
-        if (newVal.toString().split('.')[1]?.length > 4) {
+        if (newVal.toString().split(".")[1]?.length > 4) {
           newVal = newVal.toFixed(4);
         }
 
         editor.replaceToken(index, newVal, update, true);
-
       }
     }
-  })
+  });
 
-  editor.load('MAIN');
+  editor.load("MAIN");
 });


### PR DESCRIPTION
Updates data structures such that a parsed SLOP
program is represented using native SLOP runtime
data types such as `list`, `symbol`, `number`,
etc.

Along that same line, simplifies these data
structures such that we're as close to `1:1` with
`SLOP-native:Js-native` types. A list is a JS
array, a dict is a JS object, etc. The one place
we had to diverge slightly is with symbols and
keywords.

SLOP types can be tested via `SlopPred`,
constructed via `SlopVal`, and maninpulated via
`Slop<Type>` APIs e.g. `SlopList`, all opaquely.
In retrospect, the utility of the `Slop<Type>`
APIs is questionable, since most of their
contracts is that they're 1-1 with JS types. This
way at least, we have some room for divergence.
